### PR TITLE
Updated a header file which includes all standard library.

### DIFF
--- a/common_ds_algo_problems/findDigits.cpp
+++ b/common_ds_algo_problems/findDigits.cpp
@@ -30,13 +30,8 @@
  * 3
  */
 
-#include <cmath>
-#include <cstdio>
-#include <vector>
-#include <iostream>
-#include <algorithm>
+#include <bits/stdc++.h>
 using namespace std;
-
 
 int main() {
     int T, num;


### PR DESCRIPTION
#include <bits/stdc++. h> is an implementation file for a precompiled header. This file includes all standard library. Sometimes in some coding contests, when we have to save time while solving, then using this header file is helpful. In software engineering approach we should minimize the include.